### PR TITLE
Owlvit Hot FIx

### DIFF
--- a/spot_rl_experiments/spot_rl/models/owlvit.py
+++ b/spot_rl_experiments/spot_rl/models/owlvit.py
@@ -8,6 +8,8 @@ import argparse
 class OwlVit():
     def __init__(self, labels, score_threshold, show_img):
         #self.device = torch.device('cpu')
+
+        labels = [[f'an image of a {label}' for label in labels]]
         self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
 
         self.model = OwlViTForObjectDetection.from_pretrained('google/owlvit-base-patch32')


### PR DESCRIPTION
Reading the [owlvit](https://arxiv.org/pdf/2205.06230.pdf) paper they actually prompt is as:

<img width="1219" alt="image" src="https://github.com/facebookresearch/spot-sim2real/assets/35473819/26cd7f6e-6d91-4857-b02d-11774b939283">

OWL-ViT is trained on text templates, hence you can get better predictions by querying the image with text templates used in training the original model [CLIP](https://arxiv.org/abs/2103.00020) model: “photo of a star-spangled banner”, “image of a shoe”. 

I expect this PR to bump performance on detections, can you test it out next week @KavitShah1998? 