### PR TITLE
Add return_to_base flag to trigger/bypass docking behavior

### DIFF
--- a/spot_rl_experiments/configs/config.yaml
+++ b/spot_rl_experiments/configs/config.yaml
@@ -65,3 +65,6 @@ USE_DEBLURGAN: True
 IMAGE_SCALE: 0.7
 # After this many time steps of not seeing the current target object, we become open to looking for new ones
 FORGET_TARGET_OBJECT_STEPS: 15
+
+# Docking (currently only used by ASC, Seq Exp and Language env)
+RETURN_TO_BASE: True

--- a/spot_rl_experiments/spot_rl/envs/lang_env.py
+++ b/spot_rl_experiments/spot_rl/envs/lang_env.py
@@ -56,6 +56,9 @@ def main(spot, use_mixer, config, out_path=None):
     rospy.set_param("/viz_object", "None")
     rospy.set_param("/viz_place", "None")
 
+    # Check if robot should return to base
+    return_to_base = config.RETURN_TO_BASE
+
     audio_to_text = WhisperTranslator()
     sentence_similarity = SentenceSimilarity()
     with initialize(config_path="../llm/src/conf"):
@@ -132,27 +135,32 @@ def main(spot, use_mixer, config, out_path=None):
         env.stopwatch.print_stats(latest=True)
 
     # Go to the dock
-    env.say("Finished object rearrangement. Heading to dock.")
-    waypoint = nav_target_from_waypoints("dock")
-    observations = env.reset(waypoint=waypoint)
-    expert = Tasks.NAV
+    env.say(f"Finished object rearrangement. RETURN_TO_BASE - {return_to_base}.")
+    if return_to_base:
+        waypoint = nav_target_from_waypoints("dock")
+        observations = env.reset(waypoint=waypoint)
+        expert = Tasks.NAV
 
-    while True:
-        base_action, arm_action = policy.act(observations, expert=expert)
-        nav_silence_only = True
-        env.stopwatch.record("policy_inference")
-        observations, _, done, info = env.step(
-            base_action=base_action,
-            arm_action=arm_action,
-            nav_silence_only=nav_silence_only,
-        )
-        try:
-            spot.dock(dock_id=DOCK_ID, home_robot=True)
-            spot.home_robot()
-            break
-        except Exception:
-            print("Dock not found... trying again")
-            time.sleep(0.1)
+        while True:
+            base_action, arm_action = policy.act(observations, expert=expert)
+            nav_silence_only = True
+            env.stopwatch.record("policy_inference")
+            observations, _, done, info = env.step(
+                base_action=base_action,
+                arm_action=arm_action,
+                nav_silence_only=nav_silence_only,
+            )
+            try:
+                spot.dock(dock_id=DOCK_ID, home_robot=True)
+                spot.home_robot()
+                break
+            except Exception:
+                print("Dock not found... trying again")
+                time.sleep(0.1)
+    else:
+        env.say("Since RETURN_TO_BASE was set to false in config.yaml, will sit down.")
+        time.sleep(2)
+        spot.sit()
 
     print("Done!")
 


### PR DESCRIPTION
This PR handles 2 things

1. If robot started on base (with power), robot will come back and dock successfully after finishing all the tasks.
2. If robot started off base (or if base did not have power), robot will remember its starting location, come back to its starting location after finishing all the tasks and sit down at the starting location.


This would ensure that robot is usable even in tight spaces by removing the charging dock as docking behavior needs some safe distance.

**Very important fix for CVPR demo**