### PR TITLE
Fixing ariaWorld pose to spotWorld pose transformation

### DIFF
--- a/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
+++ b/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
@@ -530,7 +530,7 @@ class SpotAriaP1Node:
         x += offset * np.cos(theta)
         y += offset * np.sin(theta)
         # rotate theta by pi
-        theta += np.pi
+        theta = (theta + np.pi) % (2 * np.pi)  # normalize theta!!
 
         return (x, y, theta)
 

--- a/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
+++ b/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
@@ -340,7 +340,7 @@ class SpotAriaP1Node:
             rospy.sleep(0.5)
         try:
             transform_stamped_spotWorld_T_ariaWorld = self._tf_buffer.lookup_transform(
-                target_frame="spotWorld", source_frame="ariaWorld", time=rospy.Time(0)
+                target_frame="ariaWorld", source_frame="spotWorld", time=rospy.Time(0)
             )
         except (LookupException, ConnectivityException, ExtrapolationException):
             raise RuntimeError("Unable to lookup transform from ariaWorld to spotWorld")

--- a/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
+++ b/aria_data_loaders/aria_data_utils/spot_aria_p1_node.py
@@ -530,7 +530,7 @@ class SpotAriaP1Node:
         x += offset * np.cos(theta)
         y += offset * np.sin(theta)
         # rotate theta by pi
-        theta = (theta + np.pi) % (2 * np.pi)  # normalize theta!!
+        theta = (theta + np.pi) % (2 * np.pi) - np.pi  # normalize theta!!
 
         return (x, y, theta)
 


### PR DESCRIPTION
Actual bug was wrong use of `lookup_transform`. We were expecting target_T_source, however it returns source_T_target. Fixed.

Other hygiene:
- Wrapping rotated rotation within `(-pi, pi)` range after adding theta.