### PR TITLE
Refactor spotqrdetector class and spot interface

### DIFF
--- a/perception_and_utils_root/perception_and_utils/perception/detector_wrappers/april_tag_detector.py
+++ b/perception_and_utils_root/perception_and_utils/perception/detector_wrappers/april_tag_detector.py
@@ -35,9 +35,6 @@ class AprilTagDetectorWrapper(GenericDetector):
         # Create an instance of AprilTagDetectorWrapper
         atdw = AprilTagDetectorWrapper()
 
-        # Enable detector
-        atdw.enable_detector() # base class method
-
         # Initialize detector
         outputs = atdw._init_april_tag_detector(focal_lengths, principal_point)
 
@@ -45,15 +42,18 @@ class AprilTagDetectorWrapper(GenericDetector):
         updated_img_frame, camera_T_marker = atdw.process_frame(img_frame)
 
         # Get outputs
-        updated_img_frame, outputs = atdw.get_outputs(img_frame, outputs, camera_T_marker, img_metadata)
+        updated_img_frame, outputs = atdw.get_outputs(img_frame, outputs, base_T_marker, timestamp, img_metadata)
     """
 
     def __init__(self):
         super().__init__()
-        self.logger = logging.getLogger("AprilTagDetectorWrapper")
+        self._logger = logging.getLogger("AprilTagDetectorWrapper")
 
     def _init_april_tag_detector(
-        self, focal_lengths: Any, principal_point: Any, verbose: bool = True
+        self,
+        focal_lengths: Tuple[float, float],
+        principal_point: Tuple[float, float],
+        verbose: bool = True,
     ) -> Dict[str, Any]:
         """
         Initialize April tag detector object for pose estimation of QR code
@@ -61,34 +61,37 @@ class AprilTagDetectorWrapper(GenericDetector):
         NOTE: Can only detect april tag from spot's dock
 
         Args:
-            focal_lengths (Any) : Focal lengths of camera
-            principal_point (Any) : Principal point of camera
+            focal_lengths (Tuple[float, float]) : Focal lengths of camera
+            principal_point (Tuple[float, float]) : Principal point of camera
             verbose (bool) : If True, modifies image frame to render detected QR code
 
         Returns:
             Dict[str, Any] : Dictionary of outputs
             Manipulates following keys in the outputs dictionary:
-                - tag_device_T_marker_list (List[sp.SE3]) : List of camera_T_marker (Sophus SE3) poses
+                - tag_base_T_marker_list (List[sp.SE3]) : List of base_T_marker (Sophus SE3) poses where
+                                                          base can be "spot" for Spot or "device" for aria
                 - tag_image_list (List[np.ndarray]) : List of decorated image frames
                 - tag_image_metadata_list (List[Any]) : List of image metadata
         """
-        assert self.is_enabled is True
+        self.enable_detector()
         self.verbose = verbose
 
         calib_dict = {
-            "fx": focal_lengths[0].item(),
-            "fy": focal_lengths[1].item(),
-            "ppx": principal_point[0].item(),
-            "ppy": principal_point[1].item(),
+            "fx": focal_lengths[0],
+            "fy": focal_lengths[1],
+            "ppx": principal_point[0],
+            "ppy": principal_point[1],
             "coeffs": [0.0, 0.0, 0.0, 0.0, 0.0],
         }
 
-        self._qr_pose_estimator = AprilTagPoseEstimator(camera_intrinsics=calib_dict)
+        self._qr_pose_estimator = AprilTagPoseEstimator(
+            camera_intrinsics=calib_dict, verbose=verbose
+        )
         self._qr_pose_estimator.register_marker_ids([DOCK_ID])  # type:ignore
 
         # Initialize output dictionary
         outputs: Dict[str, Any] = {}
-        outputs["tag_device_T_marker_list"] = []
+        outputs["tag_base_T_marker_list"] = []
         outputs["tag_image_list"] = []
         outputs["tag_image_metadata_list"] = []
         return outputs
@@ -109,11 +112,14 @@ class AprilTagDetectorWrapper(GenericDetector):
         """
         # Do nothing if detector is not enabled
         if self.is_enabled is False:
+            self._logger.warning(
+                "AprilTag detector is disabled... Skipping processing of current frame."
+            )
             return img_frame, None
 
         # Detect QR code and estimate marker pose wrt camera
         updated_img_frame, camera_T_marker = self._qr_pose_estimator.detect_markers_and_estimate_pose(  # type: ignore
-            image=img_frame, should_render=self.verbose
+            image=img_frame
         )
 
         return updated_img_frame, camera_T_marker
@@ -122,7 +128,7 @@ class AprilTagDetectorWrapper(GenericDetector):
         self,
         img_frame: np.ndarray,
         outputs: Dict,
-        device_T_marker,
+        base_T_marker: sp.SE3,
         timestamp: int,
         img_metadata: Any,
     ) -> Tuple[np.ndarray, Dict]:
@@ -132,14 +138,15 @@ class AprilTagDetectorWrapper(GenericDetector):
         Args:
             img_frame (np.ndarray) : Image frame to process
             outputs (Dict) : Dictionary of outputs (to be updated)
-            device_T_marker (sp.SE3) : SE3 matrix representing marker frame as detected in device frame
+            base_T_marker (sp.SE3) : SE3 matrix representing marker frame as detected in device frame
             img_metadata (Any) : Image metadata
 
         Returns:
             img_frame (np.ndarray) : Image frame with detections and text for visualization
             outputs (Dict) : Updated dictionary of outputs
             Manipulates following keys in the outputs dictionary:
-                - tag_device_T_marker_list (List[sp.SE3]) : List of camera_T_marker (Sophus SE3) poses
+                - tag_base_T_marker_list (List[sp.SE3]) : List of base_T_marker (Sophus SE3) poses where
+                                                          base can be "spot" for Spot or "device" for aria
                 - tag_image_list (List[np.ndarray]) : List of decorated image frames
                 - tag_image_metadata_list (List[Any]) : List of image metadata
 
@@ -148,13 +155,13 @@ class AprilTagDetectorWrapper(GenericDetector):
         img = decorate_img_with_text_for_qr(
             img=img_frame,
             frame_name_str="device",
-            qr_position=device_T_marker.translation(),
+            qr_position=base_T_marker.translation(),
         )
-        self.logger.debug(f"Time stamp with AprilTag Detections- {timestamp}")
+        self._logger.debug(f"Time stamp with AprilTag Detections- {timestamp}")
 
         # Append data to lists for return
         outputs["tag_image_list"].append(img)
-        outputs["tag_device_T_marker_list"].append(device_T_marker)
+        outputs["tag_base_T_marker_list"].append(base_T_marker)
         if img_metadata is not None:
             outputs["tag_image_metadata_list"].append(img_metadata)
 

--- a/perception_and_utils_root/perception_and_utils/perception/detector_wrappers/object_detector.py
+++ b/perception_and_utils_root/perception_and_utils/perception/detector_wrappers/object_detector.py
@@ -29,9 +29,6 @@ class ObjectDetectorWrapper(GenericDetector):
         # Create an instance of ObjectDetectorWrapper
         odw = ObjectDetectorWrapper()
 
-        # Enable detector
-        odw.enable_detector() # base class method
-
         # Initialize detector
         outputs = odw._init_object_detector(object_labels, verbose)
 
@@ -67,7 +64,7 @@ class ObjectDetectorWrapper(GenericDetector):
                 - object_image_segment_list (List[int]) : List of image segment ids
                 - object_score_list (List[float]) : List of scores for each image frame
         """
-        assert self.is_enabled is True
+        self.enable_detector()
         self.verbose = verbose
 
         self.object_detector = OwlVit(
@@ -216,6 +213,9 @@ class ObjectDetectorWrapper(GenericDetector):
         """
         # Do nothing if detector is not enabled
         if self.is_enabled is False:
+            self._logger.warning(
+                "Object detector is disabled... Skipping processing of current frame."
+            )
             return img_frame, {}
 
         (_, object_scores, _, updated_img_frame,) = self._get_scored_object_detections(
@@ -238,6 +238,9 @@ class ObjectDetectorWrapper(GenericDetector):
         """
         # Do nothing if detector is not enabled
         if self.is_enabled is False:
+            self._logger.warning(
+                "Object detector is disabled... Skipping processing of current frame."
+            )
             return img_frame, {}
 
         (

--- a/perception_and_utils_root/perception_and_utils/utils/conversions.py
+++ b/perception_and_utils_root/perception_and_utils/utils/conversions.py
@@ -111,6 +111,19 @@ def bd_SE3Pose_to_ros_Pose(bd_se3: SE3Pose) -> Pose:
     return pose
 
 
+def ros_Pose_to_bd_SE3Pose(ros_pose: Pose) -> SE3Pose:
+    """
+    Convert a ROS Pose to SE3Pose
+
+    Args:
+        bd_se3 (SE3Pose): Boston Dynamics SE3Pose object
+
+    Returns:
+        Pose: ROS Pose object
+    """
+    raise NotImplementedError("Not implemented yet")
+
+
 def bd_SE3Pose_to_ros_TransformStamped(
     bd_se3: SE3Pose, parent_frame: str, child_frame: str
 ) -> TransformStamped:
@@ -142,6 +155,23 @@ def bd_SE3Pose_to_ros_TransformStamped(
     ros_trf_stamped.transform.rotation.z = float(quat.z)
     ros_trf_stamped.transform.rotation.w = float(quat.w)
     return ros_trf_stamped
+
+
+def ros_TransformStamped_to_bd_SE3Pose(
+    ros_trf_stamped: TransformStamped, parent_frame: str, child_frame: str
+) -> SE3Pose:
+    """
+    Convert a ROS TransformStamped to BD SE3Pose
+
+    Args:
+        ros_trf_stamped (TransformStamped): ROS TransformStamped object
+        parent_frame (str): Parent frame name
+        child_frame (str): Child frame name
+
+    Returns:
+        bd_se3 (SE3Pose): Boston Dynamics SE3Pose object
+    """
+    raise NotImplementedError("Not implemented yet")
 
 
 def sophus_SE3_to_ros_TransformStamped(
@@ -233,7 +263,7 @@ def sophus_SE3_to_ros_PoseStamped(sp_se3: sp.SE3, parent_frame: str) -> PoseStam
     return ros_pse_stamped
 
 
-def ros_PoseStamped_to_sp_SE3(ros_pse_stamped: PoseStamped) -> sp.SE3:
+def ros_PoseStamped_to_sophus_SE3(ros_pse_stamped: PoseStamped) -> sp.SE3:
     """
     Convert a ROS PoseStamped to a Sophus SE3
 
@@ -257,6 +287,45 @@ def ros_PoseStamped_to_sp_SE3(ros_pse_stamped: PoseStamped) -> sp.SE3:
     return sp.SE3(
         Rotation.from_quat(quat).as_matrix(), trans
     )  # Rotation.from_quat() takes a quaternion in the form of [x, y, z, w]
+
+
+def bd_SE3Pose_to_sophus_SE3(bd_se3: SE3Pose) -> sp.SE3:
+    """
+    Convert a BD SE3Pose to a Sophus SE3
+
+    Args:
+        bd_se3 (SE3Pose): BD SE3Pose object
+
+    Returns:
+        sp_SE3 (sp.SE3): Sophus SE3 object
+    """
+    trans = np.array([0.0, 0.0, 0.0])
+    trans[0] = bd_se3.position.x
+    trans[1] = bd_se3.position.y
+    trans[2] = bd_se3.position.z
+
+    quat = np.array([0.0, 0.0, 0.0, 1.0])
+    quat[0] = bd_se3.rotation.x
+    quat[1] = bd_se3.rotation.y
+    quat[2] = bd_se3.rotation.z
+    quat[3] = bd_se3.rotation.w
+
+    return sp.SE3(
+        Rotation.from_quat(quat).as_matrix(), trans
+    )  # Rotation.from_quat() takes a quaternion in the form of [x, y, z, w]
+
+
+def sophus_SE3_to_bd_SE3Pose(sp_se3: sp.SE3) -> SE3Pose:
+    """
+    Convert a Sophus SE3 to a BD SE3Pose
+
+    Args:
+        sp_se3 (sp.SE3): Sophus SE3 object
+
+    Returns:
+        bd_se3 (SE3Pose): BD SE3Pose object
+    """
+    raise NotImplementedError("Not implemented yet")
 
 
 def np_matrix3x4_to_sophus_SE3(np_matrix: np.ndarray) -> sp.SE3:

--- a/perception_and_utils_root/perception_and_utils/utils/generic_utils.py
+++ b/perception_and_utils_root/perception_and_utils/utils/generic_utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Any, List, Optional, Tuple
+
+
+def map_user_input_to_boolean(prompt):
+    """
+    Maps user input to boolean
+
+    Args:
+        prompt (str): Prompt to display to user
+
+    Returns:
+        bool: True if user input is y or yes, False if user input is n or no
+    """
+    while True:
+        user_input = input(prompt + "(y/n): ").strip()
+        if user_input.lower() in ["y", "yes"]:
+            return True
+        elif user_input.lower() in ["n", "no"]:
+            return False
+        else:
+            print("Please enter a valid input - y, yes, n or no")
+
+
+def conditional_print(message: str, verbose: bool = False):
+    """
+    Print the message if the verbose flag is set to True
+
+    Args:
+        message (str): Message to be printed if verbose is True (can also be f-string)
+        verbose (bool): Flag to determine whether to print the message or not
+    """
+    if verbose:
+        print(message)

--- a/perception_and_utils_root/perception_and_utils/utils/math_utils.py
+++ b/perception_and_utils_root/perception_and_utils/utils/math_utils.py
@@ -52,7 +52,7 @@ def get_running_avg_a_T_b(
     a_T_intermediate: sp.SE3,
     intermediate_T_b: sp.SE3,
     filter_dist: float = FILTER_DIST,
-    fixed_list_length: int = FIXED_LIST_LENGTH,
+    fixed_data_length: int = FIXED_LIST_LENGTH,
 ) -> Tuple[List[np.ndarray], List[np.ndarray], Optional[sp.SE3]]:
     """
      Computes and returns average transformation of frame a to frame b via an intermediate frame (a_T_intermediate & intermediate_T_b).
@@ -70,7 +70,7 @@ def get_running_avg_a_T_b(
          a_T_intermediate (sp.SE3): Sophus SE3 object representing transformation of frame intermediate in frame a. This is most recent data.
          intermediate_T_b (sp.SE3): Sophus SE3 object representing transformation of frame b in frame intermediate. This is most recent data.
          filter_dist (float, optional): Distance threshold for valid detections. Defaults to FILTER_DIST.
-         fixed_list_length (int, optional): Maximum size of the list. Defaults to FIXED_LIST_LENGTH.
+         fixed_data_length (int, optional): Maximum size of the list. Defaults to FIXED_LIST_LENGTH.
 
     # Returns:
          a_T_b_position_list (List[np.ndarray]): List of positions of frame b in frame a. Will be updated
@@ -89,7 +89,7 @@ def get_running_avg_a_T_b(
     # Consider only those detections where frame b is within a certain distance of the frame a measured in frame world
     if dist < filter_dist:
         # If the number of detections exceeds the fix list length, remove the first element
-        if len(a_T_b_position_list) >= fixed_list_length:
+        if len(a_T_b_position_list) >= fixed_data_length:
             a_T_b_position_list.pop(0)
             a_T_b_quaternion_list.pop(0)
 
@@ -109,5 +109,8 @@ def get_running_avg_a_T_b(
     else:
         # If the latest detection is not within the filter distance, then do not update the list
         avg_a_T_b = current_avg_a_T_b
+        print(
+            f"Dist ({dist}) exceeds filter distance limit ({filter_dist}). Skipping iteration"
+        )
 
     return a_T_b_position_list, a_T_b_quaternion_list, avg_a_T_b

--- a/spot_rl_experiments/configs/ros_frame_names.yaml
+++ b/spot_rl_experiments/configs/ros_frame_names.yaml
@@ -9,6 +9,7 @@ MARKER: "marker"
 
 
 # Frames names specific to Spot
+SPOT_BODY: "body"
 SPOT_WORLD_ODOM: "odom"
 SPOT_WORLD_VISION: "vision"
 SPOT_ARM_SHOULDER_0: "arm0.sh0"

--- a/spot_rl_experiments/experiments/skill_test/test_heurisitic_gaze.py
+++ b/spot_rl_experiments/experiments/skill_test/test_heurisitic_gaze.py
@@ -6,10 +6,11 @@
 import sys
 
 import numpy as np
+from perception_and_utils.utils.generic_utils import map_user_input_to_boolean
 from spot_rl.envs.skill_manager import SpotSkillManager
 from spot_rl.utils.construct_configs import construct_config_for_nav
 from spot_rl.utils.heuristic_nav import heurisitic_object_search_and_navigation
-from spot_rl.utils.utils import get_default_parser, map_user_input_to_boolean
+from spot_rl.utils.utils import get_default_parser
 
 
 def parse_arguments(args=sys.argv[1:]):

--- a/spot_rl_experiments/experiments/skill_test/test_mobile_gaze.py
+++ b/spot_rl_experiments/experiments/skill_test/test_mobile_gaze.py
@@ -7,7 +7,7 @@ import numpy as np
 from spot_rl.envs.skill_manager import SpotSkillManager
 
 if __name__ == "__main__":
-    from spot_rl.utils.utils import map_user_input_to_boolean
+    from perception_and_utils.utils.generic_utils import map_user_input_to_boolean
 
     # Pick Targets from Aria with +- 10 degree angle change
     pick_targets = [

--- a/spot_rl_experiments/spot_rl/envs/skill_manager.py
+++ b/spot_rl_experiments/spot_rl/envs/skill_manager.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 from multimethod import multimethod
+from perception_and_utils.utils.generic_utils import conditional_print
 from spot_rl.skills.atomic_skills import Navigation, Pick, Place
 from spot_rl.utils.construct_configs import (
     construct_config_for_gaze,
@@ -18,7 +19,6 @@ from spot_rl.utils.heuristic_nav import (
     heurisitic_object_search_and_navigation,
 )
 from spot_rl.utils.utils import (
-    conditional_print,
     get_waypoint_yaml,
     nav_target_from_waypoint,
     place_target_from_waypoint,

--- a/spot_rl_experiments/spot_rl/skills/atomic_skills.py
+++ b/spot_rl_experiments/spot_rl/skills/atomic_skills.py
@@ -7,6 +7,10 @@ import time
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
+from perception_and_utils.utils.generic_utils import (
+    conditional_print,
+    map_user_input_to_boolean,
+)
 from spot_rl.envs.gaze_env import SpotGazeEnv
 
 # Import Envs
@@ -30,7 +34,6 @@ from spot_rl.utils.geometry_utils import (
     is_pose_within_bounds,
     is_position_within_bounds,
 )
-from spot_rl.utils.utils import conditional_print, map_user_input_to_boolean
 
 # Import core classes
 from spot_wrapper.spot import Spot

--- a/spot_rl_experiments/spot_rl/utils/utils.py
+++ b/spot_rl_experiments/spot_rl/utils/utils.py
@@ -138,38 +138,6 @@ def arr2str(arr):
     return
 
 
-def map_user_input_to_boolean(prompt):
-    """
-    Maps user input to boolean
-
-    Args:
-        prompt (str): Prompt to display to user
-
-    Returns:
-        bool: True if user input is y or yes, False if user input is n or no
-    """
-    while True:
-        user_input = input(prompt + "(y/n): ").strip()
-        if user_input.lower() in ["y", "yes"]:
-            return True
-        elif user_input.lower() in ["n", "no"]:
-            return False
-        else:
-            print("Please enter a valid input - y, yes, n or no")
-
-
-def conditional_print(message: str, verbose: bool = False):
-    """
-    Print the message if the verbose flag is set to True
-
-    Args:
-        message (str): Message to be printed if verbose is True (can also be f-string)
-        verbose (bool): Flag to determine whether to print the message or not
-    """
-    if verbose:
-        print(message)
-
-
 class FixSizeOrderedDict(OrderedDict):
     def __init__(self, *args, maxlen=0, **kwargs):
         self._maxlen = maxlen


### PR DESCRIPTION
Scope <>

- [x] Use general averaging methods from math_utils.py for find avg_spotWorld_T_marker
- [x] Remove deprecated methods like `convert_transformation_from_sophus_to_magnum` & `xyz`
- [x] Generalize SpotQRDetector to work on any camera source of spot
- [x] Add method to find transformation between 2 camera sources on spot.
- [x] For `get_avg_spotWorld_T_marker_HAND()`, make it generic by accepting `cam_id` as input .
- [x] ~Make `_get_body_T_handcam` as `_get_body_T_camframe` or something~ Remove `_get_body_T_handcam` and replace with `get_spot_a_T_b.