### PR TITLE
Use weights_only for load

### DIFF
--- a/spot_rl_experiments/spot_rl/real_policy.py
+++ b/spot_rl_experiments/spot_rl/real_policy.py
@@ -87,7 +87,7 @@ class RealPolicy:
             )
         else:
             if isinstance(checkpoint_path, str):
-                checkpoint = torch.load(checkpoint_path, map_location="cpu")
+                checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
             else:
                 checkpoint = checkpoint_path
 
@@ -461,7 +461,7 @@ class MixerPolicy(RealPolicy):
                 ),
             }
         )
-        checkpoint = torch.load(mixer_checkpoint_path, map_location="cpu")
+        checkpoint = torch.load(mixer_checkpoint_path, map_location="cpu", weights_only=True)
         checkpoint["config"].RL.POLICY["nav_checkpoint_path"] = nav_checkpoint_path
         checkpoint["config"].RL.POLICY["gaze_checkpoint_path"] = gaze_checkpoint_path
         checkpoint["config"].RL.POLICY["place_checkpoint_path"] = place_checkpoint_path

--- a/spot_rl_experiments/utils/pytorch_to_torchscript.py
+++ b/spot_rl_experiments/utils/pytorch_to_torchscript.py
@@ -121,7 +121,7 @@ class PolicyConverter:
         self.device = torch.device(device)
 
         # Load the checkpoint
-        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
 
         # Load the config
         config = checkpoint["config"]


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/