### PR TITLE
Add safety net in reading and spliting home txt data if it is empty string

### DIFF
--- a/bd_spot_wrapper/spot_wrapper/spot.py
+++ b/bd_spot_wrapper/spot_wrapper/spot.py
@@ -1222,9 +1222,11 @@ class Spot:
         if osp.isfile(HOME_TXT):
             with open(HOME_TXT) as f:
                 data = f.read()
-            global_T_home = np.array([float(d) for d in data.split(", ")[:9]])
-            global_T_home = global_T_home.reshape([3, 3])
-            robot_recenter_yaw = float(data.split(", ")[-1])
+
+            if data != "":
+                global_T_home = np.array([float(d) for d in data.split(", ")[:9]])
+                global_T_home = global_T_home.reshape([3, 3])
+                robot_recenter_yaw = float(data.split(", ")[-1])
 
         return (global_T_home, robot_recenter_yaw)
 


### PR DESCRIPTION
If home.txt exists but is empty we see the following error

```
(spot_ros) kavit@kavit-Lambda-Vector:~/fair/spot-sim2real$ spot_reset_home 
There is no intel-realsense-image_service. Using gripper cameras
Loaded gripper_T_intel (sp.SE3) as None
Reading robot pose w.r.t home from home.txt
Traceback (most recent call last):
  File "/home/kavit/miniconda3/envs/spot_ros/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/kavit/miniconda3/envs/spot_ros/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/kavit/fair/spot-sim2real/bd_spot_wrapper/spot_wrapper/home_robot.py", line 9, in <module>
    spot = Spot("NavPoseMonitor")
  File "/home/kavit/fair/spot-sim2real/bd_spot_wrapper/spot_wrapper/spot.py", line 240, in __init__
    (self.global_T_home, self.robot_recenter_yaw) = self.read_home_robot()
  File "/home/kavit/fair/spot-sim2real/bd_spot_wrapper/spot_wrapper/spot.py", line 1227, in read_home_robot
    global_T_home = np.array([float(d) for d in data.split(", ")[:9]])
  File "/home/kavit/fair/spot-sim2real/bd_spot_wrapper/spot_wrapper/spot.py", line 1227, in <listcomp>
    global_T_home = np.array([float(d) for d in data.split(", ")[:9]])
ValueError: could not convert string to float: ''
2024-10-30 17:52:15,625 - INFO - signal_shutdown [atexit]
```


After the fix

```
(spot_ros) kavit@kavit-Lambda-Vector:~/fair/spot-sim2real$ spot_reset_home 
There is no intel-realsense-image_service. Using gripper cameras
Loaded gripper_T_intel (sp.SE3) as None
Reading robot pose w.r.t home from home.txt
2024-10-30 17:52:29,712 - INFO - Current battery charge: 100.0%
Updating robot pose w.r.t home in home.txt
Wrote: 
0.999999029853683, -0.001392943535353894, 0.0018099513478254206, 0.001392943535353894, 0.999999029853683, 0.0044239618164725785, 0.0, 0.0, 1.0, -0.0014173411330888966
to: /home/kavit/fair/spot-sim2real/bd_spot_wrapper/spot_wrapper/home.txt
2024-10-30 17:52:29,832 - INFO - signal_shutdown [atexit]
(spot_ros) kavit@kavit-Lambda-Vector:~/fair/spot-sim2real$ 

```